### PR TITLE
iniconfig 2.0.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "iniconfig" %}
-{% set version = "1.1.1" %}
+{% set version = "2.0.0" %}
 
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32
+  sha256: 2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3
 
 build:
   number: 0


### PR DESCRIPTION
**Recipe directory diff between current master and this update:**
``` diff
diff --git a/recipe/meta.yaml b/recipe/meta.yaml
index 765d4b6..3e177b0 100644
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "iniconfig" %}
-{% set version = "1.1.1" %}
+{% set version = "2.0.0" %}
 
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32
+  sha256: 2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3
 
 build:
   number: 0

```

**Jira ticket:** []() (-)

**The upstream data:**

**_Actions:_**

1. 

**_Notes:_**
 * 

**Additional info:**

<details>

**Package's statistics**

<details>

 * Priority C | effort: easy | Category: other | subcategory:  | pkg_type: python
 * Outdated platfroms: 'linux-64', 'linux-aarch64', 'linux-ppc64le', 'osx-64', 'osx-arm64', 'win-64'
 * Latest version: 2.0.0
 * Release on PyPi:
    * version: 2.0.0
    * date: 2023-01-07T11:08:11
* [PyPi history](https://pypi.org/project/iniconfig/#history)
 * Popularity: 
    * 3 months downloads: 1017822.0
    * All time:  11444897 downloads -  iniconfig  2.0.0  iniconfig: brain-dead simple config-ini parsing  copy  

</details>

**Other checks:**

<details>

1. - [ ] Check the pinnings
2. - [ ] Verify that the `build_number` is correct
4. - [ ] Verify if the package needs `setuptools`
    
6. - [ ] Verify if the package needs `wheel`
    
7. - [x] `pip` in test
9. - [ ] Verify the test section
10. - [ ] Verify if the package is `architecture specific`
11. - [ ] Verify that private modules are not mentioned in the recipe For example: (_private_module)
12.  - [x] license_file: LICENSE is present

15. - [ ] License family is NOT present
    
16. - [x] License: MIT
    - [x] License is `spdx` compliant
 * Check if the license identifier has correct name from the SPDX License List

| Identifier         |
|:-------------------|
| MIT                |
| MIT-0              |
| MIT-advertising    |
| MIT-CMU            |
| MIT-enna           |
| MIT-feh            |
| MIT-Modern-Variant |
| MIT-open-group     |
| MITNFA             |
</details>

**Check dependency issues:**

<details>
../aggregate/iniconfig-feedstock/recipe/meta.yaml
Dependencies: ['setuptools_scm', 'pip', 'python']


noarch:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-ppc64le:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-s390x:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

osx-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

osx-arm64:
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

win-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

</details>

**Package Build Score: 17**


</details>



**Links:**
* [Anaconda Recipes feedstock](https://github.com/AnacondaRecipes/iniconfig-feedstock)
* [Update branch](https://github.com/AnacondaRecipes/iniconfig-feedstock/tree/2.0.0)
* [conda-forge recipe](https://github.com/conda-forge/{feedstock_name}-feedstock)
* [PyPI](https://pypi.org/project/iniconfig)
* [Diff between upstream and feature branch](https://github.com/conda-forge/iniconfig-feedstock/compare/main...AnacondaRecipes:2.0.0)
* [Diff between origin and feature branch](https://github.com/AnacondaRecipes/iniconfig-feedstock/compare/master...AnacondaRecipes:2.0.0)
* [The last merged PRs](https://github.com/AnacondaRecipes/iniconfig-feedstock/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc+)

**Updating the recipe:**
If the recipe needs additional modification the update branch can be modified. Note that the PR diffs are not updated with these changes.
```
git clone -b 2.0.0 git@github.com:AnacondaRecipes/iniconfig-feedstock.git
```
